### PR TITLE
Fixing Charge range

### DIFF
--- a/src/data/talents.js
+++ b/src/data/talents.js
@@ -343,7 +343,7 @@ var DB_talents = {
                     var reg = stats.regen.des;
                     var fatigue = stats.hp.fatigue.total;
                     var vuetotale = stats.view.total;
-                    var portee = Math.min(Utils.getPortee(reg+Math.floor(pv/10))-Math.floor((fatigue)/5), vuetotale);
+                    var portee = Math.min(Math.max(1, Utils.getPortee(reg+Math.ceil(pv/10))-Math.floor((fatigue)/5)), vuetotale);
                     
                     if(portee < 1) {
                         return $("<div/>").append("Impossible de charger !");


### PR DESCRIPTION
La fatigue réduit la portée de la charge de 1 case par 5 points de fatigue. Néanmoins, elle ne peut réduire la portée à moins d'une case.

Base de calcul Distance de Charge : (PV actuels/10 + Dés Régénération). Les PV sont arrondis au multiple de 10 supérieur (61 -> 70). 
[http://mountypedia.mountyhall.com/Mountyhall/Charger](http://mountypedia.mountyhall.com/Mountyhall/Charger)